### PR TITLE
Remove contributor username/login from image element

### DIFF
--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -123,7 +123,6 @@ const Team: NextPage = () => {
                 target="_blank"
                 key={contributor.id}
               >
-                {contributor.login[0]}
                 <Image
                   alt={`${contributor.login}'s avatar`}
                   src={contributor.avatar_url}


### PR DESCRIPTION
Currently, when the list of contributors from Github is populated, some users have transparent avatars which exposes the username first character printed behind them.

Unless there is some sort of HTML semantics reason that this is there, I wouldn't be surprised if this was just a forgotten print 😛 

*Example (see: _11 and the person beside Tux):*
<img width="1361" alt="Screen Shot 2022-08-02 at 22 13 38" src="https://user-images.githubusercontent.com/26070412/182522883-bee9262b-6173-4f60-888b-f182a01e7de4.png">

*Fixed:*
<img width="1316" alt="Screen Shot 2022-08-02 at 22 13 26" src="https://user-images.githubusercontent.com/26070412/182523013-5bfa0f2a-9204-442d-9f85-102cfe4f802c.png">