### PR TITLE
chore: improve linting setup to allow better tree-shaking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,14 @@
 {
   "extends": [
     "next/core-web-vitals",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/jsx-runtime"
   ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
   "rules": {
     "import/order": [
       "warn",
@@ -11,6 +17,13 @@
           "order": "asc"
         },
         "newlines-between": "always"
+      }
+    ],
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/consistent-type-exports": [
+      "error",
+      {
+        "fixMixedExportsWithInlineTypeSpecifier": true
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@types/node": "18.8.5",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
     "eslint": "8.25.0",
     "eslint-config-next": "12.3.1",
     "eslint-config-prettier": "8.5.0",
@@ -35,5 +37,6 @@
     "typescript": "4.8.4",
     "windicss": "3.5.6",
     "windicss-webpack-plugin": "1.7.6"
-  }
+  },
+  "sideEffects": false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ specifiers:
   '@types/node': 18.8.5
   '@types/react': 18.0.21
   '@types/react-dom': 18.0.6
+  '@typescript-eslint/eslint-plugin': ^5.40.0
+  '@typescript-eslint/parser': ^5.40.0
   clsx: 1.2.1
   eslint: 8.25.0
   eslint-config-next: 12.3.1
@@ -35,6 +37,8 @@ devDependencies:
   '@types/node': 18.8.5
   '@types/react': 18.0.21
   '@types/react-dom': 18.0.6
+  '@typescript-eslint/eslint-plugin': 5.40.0_25sstg4uu2sk4pm7xcyzuov7xq
+  '@typescript-eslint/parser': 5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q
   eslint: 8.25.0
   eslint-config-next: 12.3.1_z4bbprzjrhnsfa24uvmcbu7f5q
   eslint-config-prettier: 8.5.0_eslint@8.25.0
@@ -1730,6 +1734,10 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
+  /@types/json-schema/7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
+
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
@@ -1764,6 +1772,32 @@ packages:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
+  /@typescript-eslint/eslint-plugin/5.40.0_25sstg4uu2sk4pm7xcyzuov7xq:
+    resolution: {integrity: sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q
+      '@typescript-eslint/scope-manager': 5.40.0
+      '@typescript-eslint/type-utils': 5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q
+      '@typescript-eslint/utils': 5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q
+      debug: 4.3.4
+      eslint: 8.25.0
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser/5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q:
     resolution: {integrity: sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1792,6 +1826,26 @@ packages:
       '@typescript-eslint/visitor-keys': 5.40.0
     dev: true
 
+  /@typescript-eslint/type-utils/5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q:
+    resolution: {integrity: sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.40.0_typescript@4.8.4
+      '@typescript-eslint/utils': 5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q
+      debug: 4.3.4
+      eslint: 8.25.0
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types/5.40.0:
     resolution: {integrity: sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1816,6 +1870,25 @@ packages:
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.40.0_z4bbprzjrhnsfa24uvmcbu7f5q:
+    resolution: {integrity: sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.40.0
+      '@typescript-eslint/types': 5.40.0
+      '@typescript-eslint/typescript-estree': 5.40.0_typescript@4.8.4
+      eslint: 8.25.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.25.0
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /@typescript-eslint/visitor-keys/5.40.0:
@@ -2557,6 +2630,14 @@ packages:
       string.prototype.matchall: 4.0.7
     dev: true
 
+  /eslint-scope/5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+    dev: true
+
   /eslint-scope/7.1.1:
     resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2653,6 +2734,11 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
+    dev: true
+
+  /estraverse/4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
     dev: true
 
   /estraverse/5.3.0:

--- a/src/components/data/FeatureCard.tsx
+++ b/src/components/data/FeatureCard.tsx
@@ -1,6 +1,7 @@
-import { FunctionComponent } from "react";
+import type { FunctionComponent } from "react";
 
 export interface FeatureCardProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon: FunctionComponent<any>;
   label: string;
   description: string;

--- a/src/components/data/Skeleton.tsx
+++ b/src/components/data/Skeleton.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 export interface SkeletonProps {
   className?: string;

--- a/src/components/data/SoftwareBuildChanges.tsx
+++ b/src/components/data/SoftwareBuildChanges.tsx
@@ -1,6 +1,7 @@
-import React, { Fragment, ReactElement } from "react";
+import type { ReactElement } from "react";
+import { Fragment } from "react";
 
-import { Build } from "@/lib/service/types";
+import type { Build } from "@/lib/service/types";
 import styles from "@/styles/components/data/SoftwareBuildChanges.module.css";
 
 export interface SoftwareBuildChangesProps {

--- a/src/components/data/SoftwareBuilds.tsx
+++ b/src/components/data/SoftwareBuilds.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import Skeleton from "@/components/data/Skeleton";
 import SoftwareBuildChanges from "@/components/data/SoftwareBuildChanges";
-import { Build } from "@/lib/service/types";
+import type { Build } from "@/lib/service/types";
 import { getVersionBuildDownloadURL } from "@/lib/service/v2";
 import { formatRelativeDate, formatISODateTime } from "@/lib/util/time";
 

--- a/src/components/data/SoftwareBuildsTable.tsx
+++ b/src/components/data/SoftwareBuildsTable.tsx
@@ -1,5 +1,5 @@
 import SoftwareBuildChanges from "@/components/data/SoftwareBuildChanges";
-import { Build } from "@/lib/service/types";
+import type { Build } from "@/lib/service/types";
 import { getVersionBuildDownloadURL } from "@/lib/service/v2";
 import { formatRelativeDate, formatISODateTime } from "@/lib/util/time";
 import styles from "@/styles/components/data/SoftwareBuildsTable.module.css";

--- a/src/components/data/SoftwarePreview.tsx
+++ b/src/components/data/SoftwarePreview.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
-import { FunctionComponent } from "react";
+import type { FunctionComponent } from "react";
 
 export interface SoftwarePreviewProps {
   id: string;
   name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon: FunctionComponent<any>;
   description: string;
   download?: boolean;

--- a/src/components/input/Button.tsx
+++ b/src/components/input/Button.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import Link from "next/link";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface ButtonProps {
   variant: "outlined" | "filled";

--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { FunctionComponent } from "react";
+import type { FunctionComponent } from "react";
 
 export interface IconButtonProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon: FunctionComponent<any>;
   label: string;
   href?: string;

--- a/src/components/input/SegmentedControlIem.tsx
+++ b/src/components/input/SegmentedControlIem.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactElement } from "react";
+import type { HTMLAttributes, ReactElement } from "react";
 
 const SegmentedControlItem = (
   props: HTMLAttributes<HTMLButtonElement>

--- a/src/components/input/SegmentedControls.tsx
+++ b/src/components/input/SegmentedControls.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 export interface SegmentedControlsProps {
   selectedIndex: number;

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { NextComponentType, NextPageContext } from "next";
+import type { NextComponentType, NextPageContext } from "next";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -14,9 +14,10 @@ import IconButton from "@/components/input/IconButton";
 import NavDropDown from "@/components/layout/NavDropDown";
 import NavDropDownLink from "@/components/layout/NavDropDownLink";
 import NavLink from "@/components/layout/NavLink";
-import { PageSoftwareProps } from "@/lib/util/types";
+import type { PageSoftwareProps } from "@/lib/util/types";
 
 export interface NavBarProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   component: NextComponentType<NextPageContext, any, any>;
 }
 
@@ -25,6 +26,7 @@ const NavBar = ({ component }: NavBarProps) => {
   const [showMenu, setShowMenu] = useState(false);
   const router = useRouter();
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const softwareProps: PageSoftwareProps | undefined = (component as any)[
     "softwareProps"
   ];

--- a/src/components/layout/NavDropDown.tsx
+++ b/src/components/layout/NavDropDown.tsx
@@ -1,6 +1,7 @@
 import { Transition } from "@headlessui/react";
 import clsx from "clsx";
-import { Fragment, ReactElement, ReactNode, useState } from "react";
+import type { ReactElement, ReactNode } from "react";
+import { Fragment, useState } from "react";
 
 import ChevronDownIcon from "@/assets/icons/heroicons/chevron-down.svg";
 

--- a/src/components/layout/NavDropDownLink.tsx
+++ b/src/components/layout/NavDropDownLink.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import NextLink from "next/link";
-import React, { ReactElement, ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 export interface NavDropDownLinkProps {
   href: string;

--- a/src/components/layout/NavLink.tsx
+++ b/src/components/layout/NavLink.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import NextLink from "next/link";
-import React, { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface LinkProps {
   href: string;

--- a/src/components/layout/SoftwareDownload.tsx
+++ b/src/components/layout/SoftwareDownload.tsx
@@ -1,13 +1,15 @@
 import Link from "next/link";
-import { FunctionComponent, ReactElement } from "react";
+import type { FunctionComponent, ReactElement } from "react";
 
 import SoftwareBuilds from "@/components/data/SoftwareBuilds";
 import SoftwareDownloadButton from "@/components/input/SoftwareDownloadButton";
-import { DownloadsContext, ProjectProps } from "@/lib/context/downloads";
+import type { ProjectProps } from "@/lib/context/downloads";
+import { DownloadsContext } from "@/lib/context/downloads";
 import { useVersionBuilds } from "@/lib/service/v2";
 
 export interface SoftwareDownloadProps {
   id: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon?: FunctionComponent<any>;
   description: string;
 }

--- a/src/components/layout/SoftwareHeader.tsx
+++ b/src/components/layout/SoftwareHeader.tsx
@@ -1,10 +1,11 @@
-import { FunctionComponent, ReactElement } from "react";
+import type { FunctionComponent, ReactElement } from "react";
 
 import Button from "@/components/input/Button";
 
 export interface SoftwareHeaderProps {
   id: string;
   name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon?: FunctionComponent<any>;
   header: ReactElement;
   description: string;

--- a/src/components/util/SEO.tsx
+++ b/src/components/util/SEO.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 export interface SEOProps {
   title: string;

--- a/src/lib/context/downloads.ts
+++ b/src/lib/context/downloads.ts
@@ -1,7 +1,7 @@
-import { GetStaticProps } from "next";
+import type { GetStaticProps } from "next";
 import { createContext } from "react";
 
-import { Build } from "@/lib/service/types";
+import type { Build } from "@/lib/service/types";
 import { getProject, getVersionBuilds } from "@/lib/service/v2";
 
 export interface DownloadsContextProps {

--- a/src/lib/service/github.ts
+++ b/src/lib/service/github.ts
@@ -1,4 +1,5 @@
-import useSWRInfinite, { SWRInfiniteResponse } from "swr/infinite";
+import type { SWRInfiniteResponse } from "swr/infinite";
+import useSWRInfinite from "swr/infinite";
 
 export interface Contributor {
   login: string;

--- a/src/lib/service/github.ts
+++ b/src/lib/service/github.ts
@@ -12,6 +12,7 @@ const CONTRIBUTORS_BASE_URL =
   "https://api.github.com/repos/PaperMC/Paper/contributors?per_page=100";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getURL = (pageIndex: number, previousPageData: any): string | null => {
   if (previousPageData && previousPageData.length < 100) return null;
   return `${CONTRIBUTORS_BASE_URL}&page=${pageIndex + 1}`;

--- a/src/lib/service/v2.ts
+++ b/src/lib/service/v2.ts
@@ -1,6 +1,7 @@
-import useSWR, { SWRResponse } from "swr";
+import type { SWRResponse } from "swr";
+import useSWR from "swr";
 
-import {
+import type {
   Project,
   ProjectsResponse,
   VersionBuilds,

--- a/src/pages/contributing.tsx
+++ b/src/pages/contributing.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from "next";
+import type { NextPage } from "next";
 
 import ChattingIllustration from "@/assets/illustrations/undraw/chatting.svg";
 import CodeReviewIllustration from "@/assets/illustrations/undraw/code-review.svg";

--- a/src/pages/downloads/all.tsx
+++ b/src/pages/downloads/all.tsx
@@ -1,10 +1,10 @@
-import { GetStaticProps, NextPage } from "next";
+import type { GetStaticProps, NextPage } from "next";
 import { useState } from "react";
 
 import SoftwareBuildsTable from "@/components/data/SoftwareBuildsTable";
 import DownloadsTree from "@/components/layout/DownloadsTree";
 import SEO from "@/components/util/SEO";
-import { Project } from "@/lib/service/types";
+import type { Project } from "@/lib/service/types";
 import { useVersionBuilds, getProject } from "@/lib/service/v2";
 
 const INITIAL_PROJECT = "paper";

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from "next";
+import type { NextPage } from "next";
 import Link from "next/link";
 
 import PaperIcon from "@/assets/brand/paper.svg";

--- a/src/pages/downloads/paper.tsx
+++ b/src/pages/downloads/paper.tsx
@@ -1,9 +1,10 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import PaperIcon from "@/assets/brand/paper.svg";
 import SoftwareDownload from "@/components/layout/SoftwareDownload";
 import SEO from "@/components/util/SEO";
-import { getProjectProps, ProjectProps } from "@/lib/context/downloads";
+import type { ProjectProps } from "@/lib/context/downloads";
+import { getProjectProps } from "@/lib/context/downloads";
 
 const PaperDownloads = ({ project }: ProjectProps): ReactElement => {
   return (

--- a/src/pages/downloads/velocity.tsx
+++ b/src/pages/downloads/velocity.tsx
@@ -1,9 +1,10 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import VelocityIcon from "@/assets/brand/velocity.svg";
 import SoftwareDownload from "@/components/layout/SoftwareDownload";
 import SEO from "@/components/util/SEO";
-import { getProjectProps, ProjectProps } from "@/lib/context/downloads";
+import type { ProjectProps } from "@/lib/context/downloads";
+import { getProjectProps } from "@/lib/context/downloads";
 
 const VelocityDownloads = ({ project }: ProjectProps): ReactElement => {
   return (

--- a/src/pages/downloads/waterfall.tsx
+++ b/src/pages/downloads/waterfall.tsx
@@ -1,9 +1,10 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import PaperIcon from "@/assets/brand/paper.svg";
 import SoftwareDownload from "@/components/layout/SoftwareDownload";
 import SEO from "@/components/util/SEO";
-import { getProjectProps, ProjectProps } from "@/lib/context/downloads";
+import type { ProjectProps } from "@/lib/context/downloads";
+import { getProjectProps } from "@/lib/context/downloads";
 
 const WaterfallDownloads = ({ project }: ProjectProps): ReactElement => {
   return (

--- a/src/pages/software/paper/index.tsx
+++ b/src/pages/software/paper/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import PaperIcon from "@/assets/brand/paper.svg";
 import BoltIcon from "@/assets/icons/heroicons/bolt.svg";

--- a/src/pages/software/velocity/index.tsx
+++ b/src/pages/software/velocity/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import VelocityIcon from "@/assets/brand/velocity.svg";
 import BoltIcon from "@/assets/icons/heroicons/bolt.svg";

--- a/src/pages/software/waterfall/index.tsx
+++ b/src/pages/software/waterfall/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import PaperIcon from "@/assets/brand/paper.svg";
 import BoltIcon from "@/assets/icons/heroicons/bolt.svg";


### PR DESCRIPTION
* This PR applies some of the recommendations from this article, https://madelinemiller.dev/blog/reduce-webapp-bundle-size/, to the setup
* The goal of these changes are to provide better safety through TypeScript eslint rules by giving access to type info (the Next config by default doesn't provide actual type information to the parser), and to ensure that the bundler/optimiser can do as much as possible
* Tells the Eslint parser that the React import isn't important (as it's not with NextJS)
* Uses type imports/exports, to substantially improve tree shaking capabilities
* Applies the ESLint rules with `pnpm lint --fix`
* Due to how simple this site is, improvements are minimal, but they prevent problems being introduced in the future