### PR TITLE
Disable SWR auto update everywhere

### DIFF
--- a/src/lib/service/api.ts
+++ b/src/lib/service/api.ts
@@ -1,9 +1,9 @@
 export const swrNoAutoUpdateSettings = {
-	revalidateOnFocus: false,
-	revalidateOnMount: true,
-	revalidateOnReconnect: false,
-	refreshWhenOffline: false,
-	refreshWhenHidden: false,
-	refreshInterval: 0,
-	initialSize: 100,
+  revalidateOnFocus: false,
+  revalidateOnMount: true,
+  revalidateOnReconnect: false,
+  refreshWhenOffline: false,
+  refreshWhenHidden: false,
+  refreshInterval: 0,
+  initialSize: 100,
 };

--- a/src/lib/service/api.ts
+++ b/src/lib/service/api.ts
@@ -1,0 +1,9 @@
+export const swrNoAutoUpdateSettings = {
+	revalidateOnFocus: false,
+	revalidateOnMount: true,
+	revalidateOnReconnect: false,
+	refreshWhenOffline: false,
+	refreshWhenHidden: false,
+	refreshInterval: 0,
+	initialSize: 100,
+};

--- a/src/lib/service/bstats.ts
+++ b/src/lib/service/bstats.ts
@@ -1,8 +1,9 @@
 import useSWR from "swr";
+import { swrNoAutoUpdateSettings } from "./api";
 
 const CHARTS_URL =
   "https://bstats.org/api/v1/plugins/580/charts/players/data/?maxElements=1";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-export const useBstatsPlayers = () => useSWR(CHARTS_URL, fetcher);
+export const useBstatsPlayers = () => useSWR(CHARTS_URL, fetcher, swrNoAutoUpdateSettings);

--- a/src/lib/service/github.ts
+++ b/src/lib/service/github.ts
@@ -1,5 +1,6 @@
 import type { SWRInfiniteResponse } from "swr/infinite";
 import useSWRInfinite from "swr/infinite";
+import { swrNoAutoUpdateSettings } from "./api";
 
 export interface Contributor {
   login: string;
@@ -19,12 +20,4 @@ const getURL = (pageIndex: number, previousPageData: any): string | null => {
 };
 
 export const useGitHubContributors = (): SWRInfiniteResponse<Contributor[]> =>
-  useSWRInfinite(getURL, fetcher, {
-    revalidateOnFocus: false,
-    revalidateOnMount: true,
-    revalidateOnReconnect: false,
-    refreshWhenOffline: false,
-    refreshWhenHidden: false,
-    refreshInterval: 0,
-    initialSize: 100,
-  });
+  useSWRInfinite(getURL, fetcher, swrNoAutoUpdateSettings);

--- a/src/lib/service/v2.ts
+++ b/src/lib/service/v2.ts
@@ -7,6 +7,7 @@ import type {
   VersionBuilds,
   VersionFamilyBuilds,
 } from "@/lib/service/types";
+import { swrNoAutoUpdateSettings } from "./api";
 
 const API_ENDPOINT = "https://api.papermc.io/v2";
 
@@ -14,22 +15,22 @@ const fetcher = (path: string) =>
   fetch(API_ENDPOINT + path).then((res) => res.json());
 
 export const useProjects = (): SWRResponse<ProjectsResponse> =>
-  useSWR("/projects", fetcher);
+  useSWR("/projects", fetcher, swrNoAutoUpdateSettings);
 
 export const useProject = (project: string): SWRResponse<Project> =>
-  useSWR(`/projects/${project}`, fetcher);
+  useSWR(`/projects/${project}`, fetcher, swrNoAutoUpdateSettings);
 
 export const useVersionBuilds = (
   project: string,
   version: string
 ): SWRResponse<VersionBuilds> =>
-  useSWR(`/projects/${project}/versions/${version}/builds`, fetcher);
+  useSWR(`/projects/${project}/versions/${version}/builds`, fetcher, swrNoAutoUpdateSettings);
 
 export const useVersionFamilyBuilds = (
   project: string,
   family: string
 ): SWRResponse<VersionFamilyBuilds> =>
-  useSWR(`/projects/${project}/version_group/${family}/builds`, fetcher);
+  useSWR(`/projects/${project}/version_group/${family}/builds`, fetcher, swrNoAutoUpdateSettings);
 
 // TODO: Better error handling?
 const getJSON = <T>(path: string): Promise<T> => fetcher(path);


### PR DESCRIPTION
Disables SWR's automatic updating (not sure if that's the best name, maybe polling would be better) on all hooks that use SWR. The content fetched by these hooks does not change often enough to warrant updating on tab-in or every X seconds (maybe builds? But those are at most only updated every few hours, so...)