### PR TITLE
fix: use monospaced font for commit ids

### DIFF
--- a/styles/components/data/SoftwareBuildChanges.module.css
+++ b/styles/components/data/SoftwareBuildChanges.module.css
@@ -1,5 +1,5 @@
 .commit {
-    @apply text-blue-600 dark:text-blue-500 mr-1;
+    @apply text-blue-600 dark:text-blue-500 mr-1 font-mono;
 }
 
 .issue {


### PR DESCRIPTION
Before:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/44026893/214241218-dad5506d-1621-429c-81d7-181160df5fd4.png">

After:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/44026893/214241188-8a2948b1-f4b5-43f5-a4e4-7341b536c90f.png">
