### PR TITLE
fix: color issue in Button for toggle experimental in Download Page

### DIFF
--- a/src/components/layout/SoftwareDownload.tsx
+++ b/src/components/layout/SoftwareDownload.tsx
@@ -77,7 +77,7 @@ const SoftwareDownload = ({
             {project.latestExperimentalVersion && (
               <button
                 className={clsx(
-                  "rounded-lg flex flex-row w-full md:w-100 border text-white transition-border pl-5 py-3",
+                  "rounded-lg flex flex-row w-full md:w-100 border transition-border pl-5 py-3",
                   isStable
                     ? "dark:border-red-500 dark:text-red-400 border-red-900 text-red-700"
                     : "dark:border-blue-600 dark:text-blue-400 border-blue-900 text-blue-700",


### PR DESCRIPTION
Fix a issue with the toggle button in download page for the people using the light mode.
Previews.
<img width="648" height="445" alt="image" src="https://github.com/user-attachments/assets/0fc92f8d-2c14-41f3-a2c8-33c06de04b34" />
<img width="566" height="464" alt="image" src="https://github.com/user-attachments/assets/ad917551-cb11-4eee-ad45-f5cb61221ff5" />
<img width="573" height="432" alt="image" src="https://github.com/user-attachments/assets/788f62ba-1ad5-47af-90b5-9e1b6466e394" />
<img width="572" height="451" alt="image" src="https://github.com/user-attachments/assets/d4d06204-ab10-47ee-9233-1d5612daed2d" />
