### PR TITLE
feat: migrate from next-sitemap to app router sitemap

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@tailwindcss/aspect-ratio": "0.4.2",
         "clsx": "2.1.1",
         "next": "15.3.5",
-        "next-sitemap": "4.2.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "sharp": "0.34.3",
@@ -236,8 +235,6 @@
     "@babel/traverse": ["@babel/traverse@7.27.7", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.27.5", "@babel/parser": "^7.27.7", "@babel/template": "^7.27.2", "@babel/types": "^7.27.7", "debug": "^4.3.1", "globals": "^11.1.0" } }, "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw=="],
 
     "@babel/types": ["@babel/types@7.27.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw=="],
-
-    "@corex/deepmerge": ["@corex/deepmerge@4.0.43", "", {}, "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.4.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.2", "tslib": "^2.4.0" } }, "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g=="],
 
@@ -969,8 +966,6 @@
 
     "next": ["next@15.3.5", "", { "dependencies": { "@next/env": "15.3.5", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.5", "@next/swc-darwin-x64": "15.3.5", "@next/swc-linux-arm64-gnu": "15.3.5", "@next/swc-linux-arm64-musl": "15.3.5", "@next/swc-linux-x64-gnu": "15.3.5", "@next/swc-linux-x64-musl": "15.3.5", "@next/swc-win32-arm64-msvc": "15.3.5", "@next/swc-win32-x64-msvc": "15.3.5", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw=="],
 
-    "next-sitemap": ["next-sitemap@4.2.3", "", { "dependencies": { "@corex/deepmerge": "^4.0.43", "@next/env": "^13.4.3", "fast-glob": "^3.2.12", "minimist": "^1.2.8" }, "peerDependencies": { "next": "*" }, "bin": { "next-sitemap": "bin/next-sitemap.mjs", "next-sitemap-cjs": "bin/next-sitemap.cjs" } }, "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ=="],
-
     "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
 
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
@@ -1278,8 +1273,6 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "next-sitemap/@next/env": ["@next/env@13.5.11", "", {}, "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg=="],
 
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,9 +1,0 @@
-/** @type {import('next-sitemap').IConfig} */
-
-const dev = process.env.NODE_ENV !== "production";
-
-module.exports = {
-  siteUrl: dev ? "http://localhost:3000" : "https://papermc.io",
-  exclude: ["/downloads/all"],
-  generateIndexSitemap: false,
-};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint"
   },
@@ -20,7 +19,6 @@
     "@tailwindcss/aspect-ratio": "0.4.2",
     "clsx": "2.1.1",
     "next": "15.3.5",
-    "next-sitemap": "4.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "sharp": "0.34.3",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,0 @@
-User-agent: *
-Disallow: /downloads/all
-Disallow: /repository/
-Disallow: /repo/
-Disallow: /api/
-Allow: /
-
-Sitemap: https://papermc.io/sitemap.xml

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const isProd = process.env.NODE_ENV === "production";
+const BASE_URL = isProd ? "https://papermc.io" : "http://localhost:3000";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/downloads/all", "/repository/", "/repo/", "/api/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+const isProd = process.env.NODE_ENV === "production";
+const BASE_URL = isProd ? "https://papermc.io" : "http://localhost:3000";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    "/community/guidelines",
+    "/downloads",
+    "/downloads/folia",
+    "/downloads/velocity",
+    "/",
+    "/software/folia",
+    "/javadocs",
+    "/community",
+    "/downloads/waterfall",
+    "/software/paper",
+    "/team",
+    "/sponsors",
+    "/software/waterfall",
+    "/software/velocity",
+    "/downloads/paper",
+    "/contribute",
+  ].map((route) => ({
+    url: new URL(route, BASE_URL).toString(),
+    lastModified: now,
+    changeFrequency: "daily",
+    priority: 0.7,
+  }));
+
+  const exclude = new Set([new URL("/downloads/all", BASE_URL).toString()]);
+
+  return [...staticRoutes].filter((item) => !exclude.has(item.url));
+}


### PR DESCRIPTION
This pull request removes the reliance on the external `next-sitemap` package and instead implements custom sitemap and robots.txt generation using Next.js's built-in capabilities. The changes improve maintainability and allow for more flexible, environment-aware configuration of sitemap and robots.txt output.

**Migration from next-sitemap to custom implementation:**

* Removed the `next-sitemap` package and its associated configuration and build step from the project (`package.json`, `next-sitemap.config.js`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13) [[3]](diffhunk://#diff-8c4981164a106326e9988c8aa5267160938ea7950f33eac3d53ef206deb31e06L1-L9)
* Deleted the static `public/robots.txt` file in favor of dynamic generation.

**Custom sitemap and robots.txt generation:**

* Added `src/app/sitemap.ts` to generate the sitemap dynamically, including only selected static routes and excluding `/downloads/all`. The sitemap is environment-aware (production vs. development).
* Added `src/app/robots.ts` to generate robots.txt rules programmatically, with appropriate allow/disallow rules and a dynamic sitemap URL based on the environment.