### PR TITLE
fix: description for folia in download page outdated

### DIFF
--- a/src/pages/downloads/index.astro
+++ b/src/pages/downloads/index.astro
@@ -27,7 +27,7 @@ import Layout from "@/layouts/Layout.astro";
         id="folia"
         name="Folia"
         icon="brand/folia"
-        description="Folia is a new fork of Paper that adds regionized multithreading to the server. Access to Folia builds isn't currently available."
+        description="Folia is a new fork of Paper that adds regionized multithreading to the server."
         type={SoftwarePreviewType.Download}
       />
     </div>


### PR DESCRIPTION
With the integration of fill, folia can be downloaded this PR fix the decription where still say builds are not available.