### PR TITLE
Use latest build endpoint for probing stable/experimental versions

### DIFF
--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,4 +1,4 @@
-import { getProject, getVersionBuilds } from "@/utils/fill";
+import { getLatestBuild, getProject, getVersionBuilds } from "@/utils/fill";
 import { getHangarProjects } from "@/utils/hangar";
 import { type ProjectDescriptor, type Build } from "@/utils/types";
 
@@ -48,8 +48,8 @@ export async function getProjectDescriptor(id: string): Promise<ProjectDescripto
     // Check for stable builds
     for (let i = flattenedVersions.length - 1; i >= 0; i--) {
       try {
-        const builds = await getVersionBuilds(id, flattenedVersions[i], "STABLE");
-        if (builds.length > 0) {
+        const build = await getLatestBuild(id, flattenedVersions[i]);
+        if (build !== null && (build.channel === "STABLE" || build.channel === "RECOMMENDED")) {
           latestStableVersion = flattenedVersions[i];
           break;
         }
@@ -84,8 +84,8 @@ export async function getProjectDescriptorWithHangar(id: string): Promise<{ proj
     // Check for stable builds
     for (let i = flattenedVersions.length - 1; i >= 0; i--) {
       try {
-        const builds = await getVersionBuilds(id, flattenedVersions[i], "STABLE");
-        if (builds.length > 0) {
+        const build = await getLatestBuild(id, flattenedVersions[i]);
+        if (build !== null && (build.channel === "STABLE" || build.channel === "RECOMMENDED")) {
           latestStableVersion = flattenedVersions[i];
           break;
         }

--- a/src/utils/fill.ts
+++ b/src/utils/fill.ts
@@ -32,6 +32,15 @@ export async function getVersionBuilds(project: string, version: string, channel
   return res.json() as Promise<Build[]>;
 }
 
+export async function getLatestBuild(project: string, version: string): Promise<Build | null> {
+  const url = `${API_ENDPOINT}/projects/${project}/versions/${version}/builds/latest`;
+  const res = await edgeFetch(url, 300);
+  if (!res.ok) {
+    throw new Error(`getLatestBuild(${project}, ${version}) failed: ${res.status}`);
+  }
+  return res.json() as Promise<Build>;
+}
+
 export async function getBStats(): Promise<{ servers: number; players: number }> {
   try {
     const res = await edgeFetch(BSTATS_URL, 300);


### PR DESCRIPTION
Things could get weird if a version gets downgraded from STABLE, but that was already the case with the existing code (just in a different way)

This is a bit more efficient for now