### PR TITLE
fix: add missing robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+Disallow: /downloads/all
+Disallow: /repository/
+Disallow: /repo/
+Disallow: /api/
+
+Sitemap: https://papermc.io/sitemap-index.xml


### PR DESCRIPTION
This pull request updates the `robots.txt` file to control how web crawlers access the site and to provide a sitemap location. The main changes are:

Search engine crawler directives:

* Allow all user agents to crawl the site except for specific paths, which are now disallowed: `/downloads/all`, `/repository/`, `/repo/`, and `/api/` (`public/robots.txt`)

Sitemap:

* Added a reference to the site's sitemap at `https://papermc.io/sitemap-index.xml` to help search engines better index the site (`public/robots.txt`)