### PR TITLE
fix(javadocs): use automatic latest version instead of manually parsing

### DIFF
--- a/src/components/data/SoftwarePreview.astro
+++ b/src/components/data/SoftwarePreview.astro
@@ -38,9 +38,6 @@ const { id, name, icon, description, type, eol } = Astro.props;
 </software-preview>
 
 <script>
-  import { getProject } from "@/utils/fill";
-  import { getLatestVersion } from "@/utils/versions";
-
   class SoftwarePreview extends HTMLElement {
     async connectedCallback() {
       const { software, previewType } = this.dataset;
@@ -61,13 +58,7 @@ const { id, name, icon, description, type, eol } = Astro.props;
           anchor.href = `/downloads/${software}`;
           break;
         case "Javadocs":
-          const { versions } = await getProject(software);
-          const latest = getLatestVersion(versions);
-          if (latest) {
-            anchor.href = `https://jd.papermc.io/${software}/${latest}`;
-          } else {
-            anchor.href = `/software/${software}`;
-          }
+          anchor.href = `https://jd.papermc.io/${software}`;
           break;
       }
     }


### PR DESCRIPTION
This fixes the issue of the Folia JavaDocs not pointing towards the correct link