### PR TITLE
feat: improve headers for downloads pages cache

### DIFF
--- a/src/pages/downloads/folia.astro
+++ b/src/pages/downloads/folia.astro
@@ -4,8 +4,8 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { fetchBuildsOrError, getProjectDescriptorOrError } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600");
+Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
+Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
 const projectResult = await getProjectDescriptorOrError("folia");
 const buildsResult = await fetchBuildsOrError(projectResult, false);
 ---

--- a/src/pages/downloads/paper.astro
+++ b/src/pages/downloads/paper.astro
@@ -4,8 +4,8 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { getProjectDescriptorOrError, fetchBuildsOrError } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600");
+Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
+Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
 const projectResult = await getProjectDescriptorOrError("paper");
 const buildsResult = await fetchBuildsOrError(projectResult, false);
 ---

--- a/src/pages/downloads/velocity.astro
+++ b/src/pages/downloads/velocity.astro
@@ -4,8 +4,8 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { getProjectDescriptorOrError, fetchBuildsOrError } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600");
+Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
+Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
 const projectResult = await getProjectDescriptorOrError("velocity");
 const buildsResult = await fetchBuildsOrError(projectResult, false);
 ---

--- a/src/pages/downloads/waterfall.astro
+++ b/src/pages/downloads/waterfall.astro
@@ -4,8 +4,8 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { getProjectDescriptorOrError, fetchBuildsOrError } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600");
+Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
+Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
 const projectResult = await getProjectDescriptorOrError("waterfall");
 const buildsResult = await fetchBuildsOrError(projectResult, false);
 


### PR DESCRIPTION
This pull request updates the HTTP caching headers for all software download pages to improve cache control and enable better performance by allowing stale content to be served while revalidation occurs. The changes apply consistent cache strategies across all project download endpoints.

Caching improvements for download pages:

* Updated the `Cache-Control` and `CDN-Cache-Control` headers in `folia.astro`, `paper.astro`, `velocity.astro`, and `waterfall.astro` to include `s-maxage=600` and `stale-while-revalidate=120`, allowing shared caches to serve stale content while revalidating and improving user experience during cache updates. [[1]](diffhunk://#diff-090bbf02d911c19467e2d917f819cd7d6e6cbebed8bf90f8a22da61d85c65270L7-R8) [[2]](diffhunk://#diff-e889f9c29dd84166377ebd07ee3541daaa7eb66f9194e6d2fc2f26637a498c93L7-R8) [[3]](diffhunk://#diff-3c2e3286217553b74cbc98d19b0e232f4c14422dd6bf35624c84e7ccb5029afdL7-R8) [[4]](diffhunk://#diff-72a7d026c707e8efb3dc79de19a857ad0dfb5a6ddf778d28b65dc597a91530e8L7-R8)