### PR TITLE
Wait on builds with promise.all

### DIFF
--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -26,17 +26,19 @@ export async function fetchDownloadsPageData(projectId: string, kv?: KVNamespace
   }
 
   const projectResult = await getProjectDescriptorOrError(projectId);
-  let stableBuildsResult: ProjectBuildsOrError | null = null;
-  let experimentalBuildsResult: ProjectBuildsOrError | null = null;
+  let stableBuildsResultPromise: Promise<ProjectBuildsOrError> | null = null;
+  let experimentalBuildsResultPromise: Promise<ProjectBuildsOrError> | null = null;
   if (projectResult.value) {
-    stableBuildsResult = await fetchBuildsOrError(projectId, projectResult.value.latestStableVersion);
+    stableBuildsResultPromise = fetchBuildsOrError(projectId, projectResult.value.latestStableVersion);
     if (projectResult.value.latestExperimentalVersion) {
-      experimentalBuildsResult = await fetchBuildsOrError(projectId, projectResult.value.latestExperimentalVersion);
+      experimentalBuildsResultPromise = fetchBuildsOrError(projectId, projectResult.value.latestExperimentalVersion);
     }
   } else {
-    stableBuildsResult = { error: projectResult.error };
-    experimentalBuildsResult = { error: projectResult.error };
+    stableBuildsResultPromise = Promise.resolve({ error: projectResult.error });
+    experimentalBuildsResultPromise = Promise.resolve({ error: projectResult.error });
   }
+
+  const [stableBuildsResult, experimentalBuildsResult] = await Promise.all([stableBuildsResultPromise, experimentalBuildsResultPromise]);
 
   return { projectResult, stableBuildsResult, experimentalBuildsResult };
 }


### PR DESCRIPTION
This pull request refactors the `fetchDownloadsPageData` function in `src/utils/download.ts` to improve performance and code clarity by fetching build data in parallel rather than sequentially.

Performance improvements:

* Changed the fetching of stable and experimental build results to use promises, allowing both to be fetched in parallel with `Promise.all`, which reduces overall waiting time for data retrieval.

Code clarity:

* Replaced direct assignment of build results with promise variables, making the asynchronous logic more explicit and easier to follow.