### PR TITLE
fix: add missing headers - oops

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
This pull request introduces a small configuration change to the static asset caching policy. The update ensures that all files under the `/_astro/` path are cached aggressively for improved performance.

* Added a `Cache-Control` header for all files in the `/_astro/` directory, setting them to be publicly cacheable for one year and marked as immutable.