### PR TITLE
Adjust navbar scroll behavior and make build separator more subtle

### DIFF
--- a/src/components/data/SoftwareBuilds.svelte
+++ b/src/components/data/SoftwareBuilds.svelte
@@ -24,7 +24,7 @@
     {#each builds.slice(0, 10) as build, idx (build.id)}
       {@const date = new Date(build.time)}
       <div>
-        <div class="flex flex-row items-center px-4 py-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-800">
+        <div class="flex flex-row items-center rounded-md px-4 py-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-800">
           <a
             role="button"
             href={build.downloads?.["server:default"]?.url}
@@ -51,7 +51,7 @@
         </div>
 
         {#if idx < Math.min(builds.length, 10) - 1}
-          <hr class="m-0 border border-gray-300 dark:border-gray-700" />
+          <hr class="mx-0 my-0.5 bg-gray-300 dark:bg-gray-700" />
         {/if}
       </div>
     {/each}

--- a/src/components/layout/NavBar.astro
+++ b/src/components/layout/NavBar.astro
@@ -56,8 +56,6 @@ import LogoMarkerLight from "@/assets/brand/logo-marker-light.svg";
   });
   window.addEventListener("scroll", () => {
     const wrapper = document.getElementById("nav-wrapper");
-    wrapper?.classList?.toggle("bg-background-light-10", window.scrollY > 64);
-    wrapper?.classList?.toggle("dark:bg-background-dark-90", window.scrollY > 64);
-    wrapper?.classList?.toggle("shadow-lg", window.scrollY > 64);
+    wrapper?.classList?.toggle("shadow-lg", window.scrollY > 1);
   });
 </script>


### PR DESCRIPTION
This pull request introduces minor UI improvements to the `SoftwareBuilds` list and adjusts the scroll behavior for the navigation bar. The changes focus on enhancing the visual appearance and user experience.

**UI enhancements to build list:**

* Added `rounded-md` to the build row container for rounded corners, improving the look of each build entry in `SoftwareBuilds.svelte`.
* Updated the separator line between build rows to use `mx-0 my-0.5` and background color classes for more consistent spacing and appearance in both light and dark themes.

**Navigation bar scroll behavior:**

* Changed the scroll threshold for applying the navigation bar shadow from `64` pixels to `1` pixel, making the shadow appear as soon as the user starts scrolling in `NavBar.astro`.