### PR TITLE
Use picture element for navbar logo

### DIFF
--- a/src/components/layout/NavBar.astro
+++ b/src/components/layout/NavBar.astro
@@ -16,8 +16,10 @@ import LogoMarkerLight from "@/assets/brand/logo-marker-light.svg";
       <Icon name="icons/heroicons/menu" class="size-6 fill-gray-500" />
     </button>
     <a href="/" class="leading-none" tabindex="-1" aria-hidden={true}>
-      <img src={LogoMarkerLight.src} alt="PaperMC" class="block h-12 cursor-pointer dark:hidden" />
-      <img src={LogoMarkerDark.src} alt="PaperMC" class="hidden h-12 cursor-pointer dark:block" />
+      <picture>
+        <source srcset={LogoMarkerDark.src} media="(prefers-color-scheme: dark)" />
+        <img src={LogoMarkerLight.src} alt="PaperMC" class="block h-12 cursor-pointer" />
+      </picture>
     </a>
     <div
       id="nav-menu"


### PR DESCRIPTION
This pull request updates the logo rendering in the navigation bar to improve support for dark mode. Instead of toggling between two separate `img` elements based on the color scheme, it now uses a `picture` element with a `source` for dark mode, simplifying the markup and ensuring better compatibility.

* Improved dark mode logo rendering by replacing two conditional `img` tags with a `picture` element containing a `source` for dark mode and a default `img` for light mode in `src/components/layout/NavBar.astro`.