### PR TITLE
fix: redirect broken link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/downloads/all https://fill-ui.papermc.io/projects


### PR DESCRIPTION
Redirects `/downloads/all` to the fill-ui explorer, this was broken with the removal of the old build explorer.