### PR TITLE
feat: improve version comparison for Paper

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -52,12 +52,24 @@ export const getProjectRepository = (project: string, version: string): string =
   if (project !== "paper") return `https://github.com/PaperMC/${project}`;
   if (project === "paper" && version === "1.7.10") return "https://github.com/PaperMC/Paper-1.7";
 
-  const baseVersion = [21, 4]; // 1.21.4 is after the hardfork
-  const isBelowBaseVersion = version
-    .replace(/^1\./, "")
-    .split(".")
-    .map(Number)
-    .some((v, i) => v < (baseVersion[i] || 0));
+  const baseVersion = "1.21.4"; // after the hardfork
 
-  return isBelowBaseVersion ? "https://github.com/PaperMC/Paper-Archive" : "https://github.com/PaperMC/Paper";
+  return isVersionBelow(version, baseVersion) ? "https://github.com/PaperMC/Paper-Archive" : "https://github.com/PaperMC/Paper";
 };
+
+function isVersionBelow(version: string, base: string): boolean {
+  const v = version.split(".").map(Number);
+  const b = base.split(".").map(Number);
+
+  const len = Math.max(v.length, b.length);
+
+  for (let i = 0; i < len; i++) {
+    const vi = v[i] ?? 0;
+    const bi = b[i] ?? 0;
+
+    if (vi < bi) return true;
+    if (vi > bi) return false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Close #219 
Previously the version check for what repo need to use remove the "1." from the version and compare.. with 26.1 and the new version format can cause issues then this PR replace that logic for compare the whole version for match and set the correct repository.