### PR TITLE
fix: a handful of astro 6 migration bugs

### DIFF
--- a/src/components/data/RemoteImageWrapper.astro
+++ b/src/components/data/RemoteImageWrapper.astro
@@ -13,13 +13,15 @@ if (props.alt === undefined || props.alt === null) {
   throw new Error("Image is missing required 'alt' property.");
 }
 
-if (typeof props.width === "string") {
-  props.width = parseInt(props.width);
+function toOptionalNumber(value: number | `${number}` | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "string" ? Number.parseInt(value, 10) : value;
 }
 
-if (typeof props.height === "string") {
-  props.height = parseInt(props.height);
-}
+const width = toOptionalNumber(props.width);
+const height = toOptionalNumber(props.height);
+props.width = width;
+props.height = height;
 
 const additionalAttributes: HTMLAttributes<"img"> = {};
 try {
@@ -37,7 +39,8 @@ if (layout !== "none") {
   props.position ??= imageConfig.objectPosition ?? "center";
 }
 
-const image = await getImage(props as any);
+// getImage has a weird type signature, so this will cast it properly to the correct type
+const image = await getImage({ ...props, width, height });
 
 if (image.srcSet.values.length > 0) {
   additionalAttributes.srcset = image.srcSet.attribute;

--- a/src/components/data/RemoteImageWrapper.astro
+++ b/src/components/data/RemoteImageWrapper.astro
@@ -1,11 +1,8 @@
 ---
 import { getImage, imageConfig, type LocalImageProps, type RemoteImageProps } from "astro:assets";
-import type { UnresolvedImageTransform } from "node_modules/astro/dist/assets/types";
 import type { HTMLAttributes } from "astro/types";
 
 import fallbackImage from "@/assets/brand/paper.svg";
-import { AstroError } from "node_modules/astro/dist/core/errors/errors";
-import { AstroErrorData } from "node_modules/astro/dist/core/errors";
 import { inferRemoteSize } from "astro/assets/utils";
 
 type Props = LocalImageProps | RemoteImageProps;
@@ -13,7 +10,7 @@ type Props = LocalImageProps | RemoteImageProps;
 const props = Astro.props;
 
 if (props.alt === undefined || props.alt === null) {
-  throw new AstroError(AstroErrorData.ImageMissingAlt);
+  throw new Error("Image is missing required 'alt' property.");
 }
 
 if (typeof props.width === "string") {
@@ -40,7 +37,7 @@ if (layout !== "none") {
   props.position ??= imageConfig.objectPosition ?? "center";
 }
 
-const image = await getImage(props as UnresolvedImageTransform);
+const image = await getImage(props as any);
 
 if (image.srcSet.values.length > 0) {
   additionalAttributes.srcset = image.srcSet.attribute;

--- a/src/components/news/Contributors.astro
+++ b/src/components/news/Contributors.astro
@@ -1,5 +1,5 @@
 ---
-import UserImage from "src/components/data/UserImage.astro";
+import UserImage from "@/components/data/UserImage.astro";
 import GitHubIcon from "@/assets/icons/fontawesome/github-brands.svg";
 import PatreonIcon from "@/assets/icons/fontawesome/patreon-brands.svg";
 import PayPalIcon from "@/assets/icons/fontawesome/paypal-brands.svg";

--- a/src/pages/internal-api/paper-playercount.ts
+++ b/src/pages/internal-api/paper-playercount.ts
@@ -1,10 +1,8 @@
-// @ts-ignore
-import { WEBSITE_CACHE } from "astro:env/server";
 import type { APIRoute } from "astro";
 import { fetchPaperBstatsPlayerCount, PAPER_PLAYERCOUNT_KEY } from "@/utils/bstats";
 
-export const GET: APIRoute = async () => {
-  const kv = WEBSITE_CACHE;
+export const GET: APIRoute = async (context) => {
+  const kv = context.locals.runtime?.env?.WEBSITE_CACHE;
   if (kv) {
     const cached = await kv.get(PAPER_PLAYERCOUNT_KEY);
     if (cached !== null) {

--- a/src/pages/internal-api/terminal.ts
+++ b/src/pages/internal-api/terminal.ts
@@ -1,12 +1,10 @@
-// @ts-ignore
-import { WEBSITE_CACHE } from "astro:env/server";
 import type { APIRoute } from "astro";
 import { downloadsPageDataKvKey, getProjectDescriptorOrError, type DownloadsPageData } from "@/utils/download";
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async (context) => {
   let ver: string | null = null;
 
-  const kv = WEBSITE_CACHE;
+  const kv = context.locals.runtime?.env?.WEBSITE_CACHE;
   if (kv) {
     const cached = await kv.get(downloadsPageDataKvKey("paper"));
     if (cached !== null) {


### PR DESCRIPTION
Three main fixes here:
- Removed internal `node_modules` resolutions. Either an older version of Vite or Astro allowed for this to happen (it shouldn't have ever worked imo). We now throw generic `Error`s. These are handled identically.
- Updates the `getImage` call to just inherit the type properly
- Moves the cache env vars to the workers injected one