### PR TITLE
fix(downloads): adjusted styling to better fit on mobile devices

### DIFF
--- a/src/components/data/SoftwareBuildChanges.svelte
+++ b/src/components/data/SoftwareBuildChanges.svelte
@@ -57,7 +57,7 @@
 
 {#if rows.length > 0}
   {#each rows as row (row.sha)}
-    <p class="commitMessage min-w-0 overflow-hidden break-words leading-relaxed [overflow-wrap:anywhere]">
+    <p class="commitMessage min-w-0 overflow-hidden leading-relaxed [overflow-wrap:anywhere] break-words">
       <a
         class="mr-1 font-mono text-blue-600 dark:text-blue-500"
         href={`${getProjectRepository(project, version)}/commit/${row.sha}`}
@@ -72,7 +72,9 @@
           {#if seg.kind === "text"}
             {seg.text}
           {:else}
-            <a class="text-blue-600 dark:text-blue-500 [overflow-wrap:anywhere]" href={seg.url} target="_blank" rel="noreferrer">{seg.text}</a>
+            <a class="[overflow-wrap:anywhere] text-blue-600 dark:text-blue-500" href={seg.url} target="_blank" rel="noreferrer"
+              >{seg.text}</a
+            >
           {/if}
         {/each}
       </span>

--- a/src/components/data/SoftwareBuildChanges.svelte
+++ b/src/components/data/SoftwareBuildChanges.svelte
@@ -57,7 +57,7 @@
 
 {#if rows.length > 0}
   {#each rows as row (row.sha)}
-    <p class="commitMessage overflow-hidden break-words" style="word-wrap: break-word; hyphens: auto;">
+    <p class="commitMessage min-w-0 overflow-hidden break-words leading-relaxed [overflow-wrap:anywhere]">
       <a
         class="mr-1 font-mono text-blue-600 dark:text-blue-500"
         href={`${getProjectRepository(project, version)}/commit/${row.sha}`}
@@ -67,12 +67,12 @@
         {row.sha.slice(0, 7)}
       </a>
 
-      <span title={row.fullMessage}>
+      <span class="min-w-0 [overflow-wrap:anywhere]" title={row.fullMessage}>
         {#each row.segments as seg, i (i)}
           {#if seg.kind === "text"}
             {seg.text}
           {:else}
-            <a class="text-blue-600 dark:text-blue-500" href={seg.url} target="_blank" rel="noreferrer">{seg.text}</a>
+            <a class="text-blue-600 dark:text-blue-500 [overflow-wrap:anywhere]" href={seg.url} target="_blank" rel="noreferrer">{seg.text}</a>
           {/if}
         {/each}
       </span>

--- a/src/components/data/SoftwareBuilds.svelte
+++ b/src/components/data/SoftwareBuilds.svelte
@@ -19,19 +19,21 @@
   }
 </script>
 
-<div class="flex flex-col">
+<div class="flex min-w-0 flex-col overflow-hidden">
   {#if builds}
     {#each builds.slice(0, 10) as build, idx (build.id)}
       {@const date = new Date(build.time)}
-      <div>
-        <div class="flex flex-row items-center rounded-md px-4 py-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-800">
+      <div class="min-w-0">
+        <div
+          class="flex min-w-0 flex-row items-start rounded-md px-0 py-2 transition-colors hover:bg-gray-200 sm:px-4 dark:hover:bg-gray-800"
+        >
           <a
             role="button"
             href={build.downloads?.["server:default"]?.url}
             target="_blank"
-            class={`btn mr-4 inline-flex min-w-16 items-center gap-1 rounded-sm p-2 text-center text-sm font-medium ${channelClass(build.channel)}`}
+            class={`btn mr-3 inline-flex min-w-14 shrink-0 items-center justify-center gap-1 rounded-sm p-2 text-center text-sm font-medium sm:mr-4 sm:min-w-16 ${channelClass(build.channel)}`}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="size-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -41,11 +43,11 @@
             #{build.id}
           </a>
 
-          <div class="flex min-w-0 flex-1 flex-col text-gray-900 dark:text-gray-200">
+          <div class="min-w-0 flex-1 overflow-hidden text-gray-900 dark:text-gray-200">
             <SoftwareBuildChanges {project} {build} {version} />
           </div>
 
-          <div class="mt-1 ml-2 hidden text-gray-500 md:block dark:text-gray-300" title={formatISODateTime(date)}>
+          <div class="mt-1 ml-2 hidden shrink-0 text-gray-500 md:block dark:text-gray-300" title={formatISODateTime(date)}>
             {formatRelativeDate(date)}
           </div>
         </div>

--- a/src/components/data/SoftwareBuilds.svelte
+++ b/src/components/data/SoftwareBuilds.svelte
@@ -33,7 +33,14 @@
             target="_blank"
             class={`btn mr-3 inline-flex min-w-14 shrink-0 items-center justify-center gap-1 rounded-sm p-2 text-center text-sm font-medium sm:mr-4 sm:min-w-16 ${channelClass(build.channel)}`}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" class="size-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"


### PR DESCRIPTION
Fixes: #268 

This pull request focuses on improving the layout and text wrapping behavior in the `SoftwareBuilds.svelte` and `SoftwareBuildChanges.svelte` components to enhance readability, especially for long commit messages and build lists. The main changes involve adding or adjusting utility classes to ensure content does not overflow and wraps correctly across different screen sizes.

**Layout and Wrapping Improvements:**

* Added `min-w-0`, `overflow-hidden`, and `[overflow-wrap:anywhere]` utility classes to various containers and text elements in both `SoftwareBuilds.svelte` and `SoftwareBuildChanges.svelte` to prevent content overflow and ensure proper word breaking for long commit messages and links. [[1]](diffhunk://#diff-fcd9c231ab77d781f1ba89f8e02eeeec7c12e50775cdd34a5e7e7a698de68d29L22-R36) [[2]](diffhunk://#diff-fcd9c231ab77d781f1ba89f8e02eeeec7c12e50775cdd34a5e7e7a698de68d29L44-R50) [[3]](diffhunk://#diff-62d9ca9055e8dba06fe3b4d1e20241c1bf731b7e9a8d30d7a450dea40fe99905L60-R60) [[4]](diffhunk://#diff-62d9ca9055e8dba06fe3b4d1e20241c1bf731b7e9a8d30d7a450dea40fe99905L70-R75)
* Adjusted flexbox and spacing classes to improve alignment and responsiveness, including tweaks to button sizing, icon shrinking, and padding for better display on small screens. [[1]](diffhunk://#diff-fcd9c231ab77d781f1ba89f8e02eeeec7c12e50775cdd34a5e7e7a698de68d29L22-R36) [[2]](diffhunk://#diff-fcd9c231ab77d781f1ba89f8e02eeeec7c12e50775cdd34a5e7e7a698de68d29L44-R50)

These changes should make build and commit information more readable and visually consistent, even with long texts or on smaller screens.

Before:
<img width="857" height="1463" alt="image" src="https://github.com/user-attachments/assets/ee31fb2a-1c13-4d74-bf5c-51d593d7e61c" />

After:
<img width="826" height="1531" alt="image" src="https://github.com/user-attachments/assets/75ba7427-a066-4177-a4ce-b88dc5b44174" />
