### PR TITLE
Implement weekly run for fetching sponsors and contributors

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,50 @@
+name: Update Data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: write
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Checkout data branch
+        uses: actions/checkout@v7
+        with:
+          ref: data
+          path: work
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Clear data branch
+        run: find work -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+
+      - name: Generate data
+        run: bun scripts/update-data.ts work
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit data
+        working-directory: work
+        run: |
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "No data changes"
+            exit 0
+          fi
+
+          git config user.name "Automated"
+          git config user.email "automated@papermc.io"
+
+          git commit -m "Update data"
+          git push origin HEAD:data

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ pnpm-debug.log*
 .eslintcache
 
 .wrangler/
+
+# data branch checkout
+work/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "bun run lint:eslint && bun run lint:prettier",
     "check": "bun run check:types",
     "check:all": "bun run check && bun run lint",
+    "data:update": "bun scripts/update-data.ts work",
     "postinstall": "wrangler types"
   },
   "dependencies": {

--- a/scripts/update-data.ts
+++ b/scripts/update-data.ts
@@ -1,0 +1,217 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+type OpenCollectiveContributor = {
+  name: string;
+  image: string;
+  totalAmountDonated: number;
+};
+
+type OpenCollectiveData = {
+  collective: {
+    name: string;
+    slug: string;
+    stats: {
+      balance: {
+        valueInCents: number;
+      };
+      monthlySpending: {
+        valueInCents: number;
+      };
+    };
+    contributors: {
+      totalCount: number;
+      nodes: OpenCollectiveContributor[];
+    };
+  };
+};
+
+type GitHubSponsor = {
+  login: string;
+  avatarUrl: string;
+};
+
+type GitHubSponsorsData = {
+  organization: {
+    sponsors: {
+      totalCount: number;
+      nodes: GitHubSponsor[];
+    };
+  };
+};
+
+type SponsorData = {
+  ocData: OpenCollectiveData;
+  ghData: GitHubSponsorsData;
+};
+
+type Contributor = {
+  login: string;
+  id: number;
+  avatar_url: string;
+  contributions: number;
+};
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: { message: string }[];
+};
+
+const outputDir = process.argv[2] ?? "work";
+const githubToken = process.env.GITHUB_TOKEN?.trim();
+
+if (!githubToken) {
+  throw new Error("GITHUB_TOKEN is required");
+}
+
+const githubHeaders = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${githubToken}`,
+  "User-Agent": "papermc-website-data-update",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+async function graphQL<T>(url: string, query: string, authorization?: string): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(authorization ? { Authorization: authorization } : {}),
+    },
+    body: JSON.stringify({ query }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GraphQL request failed: ${response.status} ${response.statusText}\n${await response.text()}`);
+  }
+
+  const result = (await response.json()) as GraphQLResponse<T>;
+
+  if (result.errors?.length) {
+    throw new Error(result.errors.map((error) => error.message).join("\n"));
+  }
+
+  if (!result.data) {
+    throw new Error("GraphQL response did not include data");
+  }
+
+  return result.data;
+}
+
+function githubAvatar64(avatarUrl: string): string {
+  const url = new URL(avatarUrl);
+
+  url.search = "";
+  url.searchParams.set("size", "64");
+
+  return url.toString();
+}
+
+async function fetchSponsors(): Promise<SponsorData> {
+  const ocData = await graphQL<OpenCollectiveData>(
+    "https://api.opencollective.com/graphql/v2",
+    `{
+      collective(slug: "papermc") {
+        name
+        slug
+        stats {
+          balance {
+            valueInCents
+          }
+          monthlySpending {
+            valueInCents
+          }
+        }
+        contributors(roles: BACKER, limit: 100) {
+          totalCount
+          nodes {
+            name
+            image
+            totalAmountDonated
+          }
+        }
+      }
+    }`
+  );
+
+  ocData.collective.contributors.nodes = ocData.collective.contributors.nodes
+    .filter((node) => node.name !== "GitHub Sponsors")
+    .sort((a, b) => b.totalAmountDonated - a.totalAmountDonated);
+
+  const openCollectiveNames = new Set(ocData.collective.contributors.nodes.map((node) => node.name));
+
+  const ghData = await graphQL<GitHubSponsorsData>(
+    "https://api.github.com/graphql",
+    `{
+      organization(login: "papermc") {
+        sponsors(first: 100) {
+          totalCount
+          nodes {
+            ... on Actor {
+              login
+              avatarUrl
+            }
+          }
+        }
+      }
+    }`,
+    `Bearer ${githubToken}`
+  );
+
+  ghData.organization.sponsors.nodes = ghData.organization.sponsors.nodes
+    .filter((node) => !openCollectiveNames.has(node.login))
+    .map((node) => ({
+      login: node.login,
+      avatarUrl: githubAvatar64(node.avatarUrl),
+    }));
+
+  return { ocData, ghData };
+}
+
+async function fetchContributors(): Promise<Contributor[]> {
+  const contributors: Contributor[] = [];
+
+  for (let page = 1; ; page++) {
+    const url = new URL("https://api.github.com/repos/PaperMC/Paper/contributors");
+
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+
+    const response = await fetch(url, { headers: githubHeaders });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch contributors page ${page}: ${response.status} ${response.statusText}\n${await response.text()}`);
+    }
+
+    const pageContributors = (await response.json()) as Contributor[];
+
+    contributors.push(
+      ...pageContributors.map(({ login, id, avatar_url, contributions }) => ({
+        login,
+        id,
+        avatar_url,
+        contributions,
+      }))
+    );
+
+    console.log(`Fetched ${pageContributors.length} contributors from page ${page}`);
+
+    if (pageContributors.length < 100) {
+      break;
+    }
+  }
+
+  return contributors;
+}
+
+const [sponsors, contributors] = await Promise.all([fetchSponsors(), fetchContributors()]);
+
+await mkdir(outputDir, { recursive: true });
+
+await writeFile(join(outputDir, "sponsors.json"), `${JSON.stringify(sponsors, null, 2)}\n`);
+await writeFile(join(outputDir, "contributors.json"), `${JSON.stringify(contributors, null, 2)}\n`);
+
+console.log(`Wrote ${sponsors.ocData.collective.contributors.nodes.length} OpenCollective sponsors`);
+console.log(`Wrote ${sponsors.ghData.organization.sponsors.nodes.length} GitHub sponsors`);
+console.log(`Wrote ${contributors.length} contributors`);

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -5,47 +5,16 @@ export interface Contributor {
   contributions: number;
 }
 
-const CONTRIBUTORS_BASE_URL = "https://api.github.com/repos/PaperMC/Paper/contributors?per_page=100";
+const CONTRIBUTORS_DATA_URL = "https://raw.githubusercontent.com/PaperMC/website/data/contributors.json";
 
-/**
- * Fetches a list of contributors from the GitHub API, paginating through results up to a specified maximum number of pages.
- *
- * The function accumulates contributors from each page until one of the following conditions is met:
- * - The maximum number of pages (`maxPages`) is reached.
- * - The response status is 403 (forbidden).
- * - The response is not OK.
- * - The returned data is not an array or is empty.
- * - The number of contributors in the current page is less than 100 (indicating the last page).
- *
- * @param maxPages - The maximum number of pages to fetch. Defaults to 15.
- * @returns A promise that resolves to an array of `Contributor` objects.
- */
-export async function fetchContributors(maxPages = 15): Promise<Contributor[]> {
-  const all: Contributor[] = [];
+export async function fetchContributors(): Promise<Contributor[]> {
+  const response = await fetch(CONTRIBUTORS_DATA_URL);
 
-  for (let page = 1; page <= maxPages; page++) {
-    const res = await fetch(`${CONTRIBUTORS_BASE_URL}&page=${page}`, {
-      headers: {
-        Accept: "application/vnd.github+json",
-      },
-    });
-
-    if (res.status === 403) {
-      break;
-    }
-
-    if (!res.ok) {
-      break;
-    }
-
-    const data = (await res.json()) as Contributor[];
-    if (!Array.isArray(data) || data.length === 0) break;
-
-    all.push(...data);
-
-    if (data.length < 100) break;
+  if (!response.ok) {
+    throw new Error(`Failed to fetch contributors: ${response.status} ${response.statusText}`);
   }
-  return all;
+
+  return response.json() as Promise<Contributor[]>;
 }
 
 export const getProjectRepository = (project: string, version: string): string => {

--- a/src/utils/sponsors.ts
+++ b/src/utils/sponsors.ts
@@ -1,15 +1,10 @@
-export interface SponsorData {
-  ocData: OpenCollectiveData;
-  ghData: GitHubSponsorsData;
-}
-
-export interface OpenCollectiveContributor {
+export type OpenCollectiveContributor = {
   name: string;
   image: string;
   totalAmountDonated: number;
-}
+};
 
-export interface OpenCollectiveData {
+export type OpenCollectiveData = {
   collective: {
     name: string;
     slug: string;
@@ -26,26 +21,35 @@ export interface OpenCollectiveData {
       nodes: OpenCollectiveContributor[];
     };
   };
-}
+};
 
-export interface GithubSponsorNode {
+export type GitHubSponsor = {
   login: string;
   avatarUrl: string;
-}
+};
 
-export interface GitHubSponsorsData {
+export type GitHubSponsorsData = {
   organization: {
     sponsors: {
       totalCount: number;
-      nodes: GithubSponsorNode[];
+      nodes: GitHubSponsor[];
     };
   };
-}
+};
+
+export type SponsorData = {
+  ocData: OpenCollectiveData;
+  ghData: GitHubSponsorsData;
+};
+
+const SPONSORS_DATA_URL = "https://raw.githubusercontent.com/PaperMC/website/data/sponsors.json";
 
 export async function fetchAllSponsors(): Promise<SponsorData> {
-  const response = await fetch("https://raw.githubusercontent.com/PaperMC/papermc.io/data/sponsors.json");
+  const response = await fetch(SPONSORS_DATA_URL);
+
   if (!response.ok) {
-    throw new Error(`Failed to fetch sponsors: ${response.statusText}`);
+    throw new Error(`Failed to fetch sponsors: ${response.status} ${response.statusText}`);
   }
+
   return response.json() as Promise<SponsorData>;
 }


### PR DESCRIPTION
This pull request introduces a new automated workflow for updating sponsor and contributor data, centralizes data fetching, and refactors how this data is retrieved and typed in the codebase. The main improvements are the addition of a scheduled GitHub Actions workflow to update data, the creation of a script to fetch and store sponsor/contributor information, and updates to the frontend code to consume this data from static JSON files rather than directly from APIs.

**Automated Data Update Workflow**
- Added a new GitHub Actions workflow (`.github/workflows/update-data.yml`) that runs weekly or manually to update sponsor and contributor data. It checks out the `data` branch, runs a data generation script, and commits any changes.

**Data Generation Script**
- Introduced a new script (`scripts/update-data.ts`) that fetches sponsors from OpenCollective and GitHub Sponsors, as well as contributors from the PaperMC repository, and writes this data to JSON files for use by the website.
- Added a `data:update` script to `package.json` to run the data update script manually.

**Frontend Data Fetching Refactor**
- Updated the contributors utility (`src/utils/github.ts`) to fetch contributor data from the static JSON file in the `data` branch, instead of paginating through the GitHub API at runtime.
- Updated the sponsors utility (`src/utils/sponsors.ts`) to fetch sponsor data from the static JSON file, and refactored types to use `type` aliases instead of `interface` for consistency with the new data source. [[1]](diffhunk://#diff-3a654ca1c820704d96fe8e9b0bd02ab04a4ea0df403c68640356e0c170d90f57L1-R7) [[2]](diffhunk://#diff-3a654ca1c820704d96fe8e9b0bd02ab04a4ea0df403c68640356e0c170d90f57L29-R53)