### PR TITLE
fix(data): add cursor and pagination for sponsors

### DIFF
--- a/scripts/update-data.ts
+++ b/scripts/update-data.ts
@@ -40,6 +40,19 @@ type GitHubSponsorsData = {
   };
 };
 
+type GitHubSponsorsPageData = {
+  organization: {
+    sponsors: {
+      totalCount: number;
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string | null;
+      };
+      nodes: GitHubSponsor[];
+    };
+  };
+};
+
 type SponsorData = {
   ocData: OpenCollectiveData;
   ghData: GitHubSponsorsData;
@@ -108,8 +121,8 @@ function githubAvatar64(avatarUrl: string): string {
   return url.toString();
 }
 
-async function fetchSponsors(): Promise<SponsorData> {
-  const ocData = await graphQL<OpenCollectiveData>(
+async function fetchOpenCollectiveSponsorsPage(offset: number): Promise<OpenCollectiveData> {
+  return graphQL<OpenCollectiveData>(
     "https://api.opencollective.com/graphql/v2",
     `{
       collective(slug: "papermc") {
@@ -123,7 +136,7 @@ async function fetchSponsors(): Promise<SponsorData> {
             valueInCents
           }
         }
-        contributors(roles: BACKER, limit: 100) {
+        contributors(roles: BACKER, limit: 100, offset: ${offset}) {
           totalCount
           nodes {
             name
@@ -134,19 +147,46 @@ async function fetchSponsors(): Promise<SponsorData> {
       }
     }`
   );
+}
 
-  ocData.collective.contributors.nodes = ocData.collective.contributors.nodes
+async function fetchOpenCollectiveSponsors(): Promise<OpenCollectiveData> {
+  const firstPage = await fetchOpenCollectiveSponsorsPage(0);
+  const contributors = [...firstPage.collective.contributors.nodes];
+
+  console.log(`Fetched ${firstPage.collective.contributors.nodes.length} OpenCollective sponsors from offset 0`);
+
+  for (let offset = 100; offset < firstPage.collective.contributors.totalCount; offset += 100) {
+    const page = await fetchOpenCollectiveSponsorsPage(offset);
+
+    contributors.push(...page.collective.contributors.nodes);
+
+    console.log(`Fetched ${page.collective.contributors.nodes.length} OpenCollective sponsors from offset ${offset}`);
+
+    if (page.collective.contributors.nodes.length < 100) {
+      break;
+    }
+  }
+
+  firstPage.collective.contributors.nodes = contributors
     .filter((node) => node.name !== "GitHub Sponsors")
     .sort((a, b) => b.totalAmountDonated - a.totalAmountDonated);
 
-  const openCollectiveNames = new Set(ocData.collective.contributors.nodes.map((node) => node.name));
+  return firstPage;
+}
 
-  const ghData = await graphQL<GitHubSponsorsData>(
+async function fetchGitHubSponsorsPage(cursor: string | null): Promise<GitHubSponsorsPageData> {
+  const after = cursor ? `, after: ${JSON.stringify(cursor)}` : "";
+
+  return graphQL<GitHubSponsorsPageData>(
     "https://api.github.com/graphql",
     `{
       organization(login: "papermc") {
-        sponsors(first: 100) {
+        sponsors(first: 100${after}) {
           totalCount
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           nodes {
             ... on Actor {
               login
@@ -158,13 +198,55 @@ async function fetchSponsors(): Promise<SponsorData> {
     }`,
     `Bearer ${githubToken}`
   );
+}
 
-  ghData.organization.sponsors.nodes = ghData.organization.sponsors.nodes
-    .filter((node) => !openCollectiveNames.has(node.login))
-    .map((node) => ({
-      login: node.login,
-      avatarUrl: githubAvatar64(node.avatarUrl),
-    }));
+async function fetchGitHubSponsors(openCollectiveNames: Set<string>): Promise<GitHubSponsorsData> {
+  const sponsors: GitHubSponsor[] = [];
+  let totalCount = 0;
+  let cursor: string | null = null;
+
+  for (;;) {
+    const page = await fetchGitHubSponsorsPage(cursor);
+    const data = page.organization.sponsors;
+
+    totalCount = data.totalCount;
+
+    sponsors.push(
+      ...data.nodes
+        .filter((node) => !openCollectiveNames.has(node.login))
+        .map((node) => ({
+          login: node.login,
+          avatarUrl: githubAvatar64(node.avatarUrl),
+        }))
+    );
+
+    console.log(`Fetched ${data.nodes.length} GitHub sponsors`);
+
+    if (!data.pageInfo.hasNextPage) {
+      break;
+    }
+
+    cursor = data.pageInfo.endCursor;
+
+    if (!cursor) {
+      throw new Error("GitHub Sponsors pagination reported another page but did not return an endCursor");
+    }
+  }
+
+  return {
+    organization: {
+      sponsors: {
+        totalCount,
+        nodes: sponsors,
+      },
+    },
+  };
+}
+
+async function fetchSponsors(): Promise<SponsorData> {
+  const ocData = await fetchOpenCollectiveSponsors();
+  const openCollectiveNames = new Set(ocData.collective.contributors.nodes.map((node) => node.name));
+  const ghData = await fetchGitHubSponsors(openCollectiveNames);
 
   return { ocData, ghData };
 }


### PR DESCRIPTION
This pull request refactors how sponsor data is fetched from OpenCollective and GitHub Sponsors in `scripts/update-data.ts`. The main improvement is the introduction of proper pagination handling for both APIs, ensuring all sponsors are retrieved even when there are more than 100 entries. The code is also reorganized for better clarity and maintainability.

**Pagination and Data Fetching Improvements:**

* Added new types `GitHubSponsorsPageData` and refactored sponsor-fetching functions to handle paginated results from both OpenCollective and GitHub APIs, ensuring all sponsor data is retrieved. [[1]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133R43-R55) [[2]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133R150-R189) [[3]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133R201-R249)
* Implemented `fetchOpenCollectiveSponsorsPage` and `fetchGitHubSponsorsPage` to fetch single pages of results, and new looping logic in `fetchOpenCollectiveSponsors` and `fetchGitHubSponsors` to aggregate all pages. [[1]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133L111-R125) [[2]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133R150-R189) [[3]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133R201-R249)

**Code Organization and Filtering:**

* Refactored the main `fetchSponsors` function to use the new paginated fetching logic and to filter out duplicate sponsors (those present in both OpenCollective and GitHub Sponsors).
* Updated sorting and filtering logic for OpenCollective sponsors, and ensured consistent sponsor data structure for further processing.

**API Query Adjustments:**

* Modified GraphQL queries to include pagination parameters (`offset` for OpenCollective, `after` cursor for GitHub Sponsors) and to request page info for proper pagination handling. [[1]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133L126-R139) [[2]](diffhunk://#diff-890a36c62ebcf578c1ba19c2f8b5a8e48929cb1d4faeac5d980095950ebc0133R150-R189)

These changes make sponsor data fetching robust, scalable, and easier to maintain.