### PR TITLE
fix: missing spacing on software and home pages

### DIFF
--- a/src/pages/downloads/waterfall.astro
+++ b/src/pages/downloads/waterfall.astro
@@ -11,17 +11,12 @@ const data = await fetchDownloadsPageData("waterfall", env.WEBSITE_CACHE);
 
 const descriptionHtml = `
   Waterfall has reached end of life. We recommend you transition to
-  <a class="text-blue-500 hover:text-blue-400 hover:underline" href="/software/velocity">
-    Velocity
-  </a>.
+  <a class="text-blue-500 hover:text-blue-400 hover:underline" href="/software/velocity">Velocity</a>.
   For more information see the
   <a
     class="text-blue-500 hover:text-blue-400 hover:underline"
     href="/news/announcing-the-end-of-life-of-waterfall"
-    rel="noopener"
-  >
-    announcement
-  </a>.
+    rel="noopener">announcement</a>.
   <br />
   Download unsupported, archived Waterfall builds below.
 `;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,8 +39,7 @@ import SoftwarePreview, { SoftwarePreviewType } from "@/components/data/Software
   <section id="software" class="bg-background-light-0 dark:bg-background-dark-80 w-full border-y pt-12 pb-8">
     <div class="mx-auto max-w-7xl">
       <h2 class="mb-4 px-6 text-xl font-semibold md:text-2xl lg:px-4">
-        Your server deserves the
-        <span class="text-blue-500">best.</span>
+        Your server deserves the <span class="text-blue-500">best.</span>
       </h2>
       <div class="grid gap-2 px-2 md:grid-cols-3 xl:gap-4">
         <SoftwarePreview
@@ -90,9 +89,7 @@ import SoftwarePreview, { SoftwarePreviewType } from "@/components/data/Software
       </div>
       <div class="flex-1">
         <h2 class="text-2xl font-semibold break-all md:text-4xl">
-          Powering <PlayersCount
-          client:load="svelte" ttlMs={12 * 60 * 1000}
-        /> players
+          Powering <PlayersCount client:load="svelte" ttlMs={12 * 60 * 1000} /> players
         </h2>
         <p class="mt-3 text-gray-900 md:mt-6 md:text-xl dark:text-gray-100">
           PaperMC&apos;s software powers hundreds of thousands of Minecraft servers on a daily basis, from small single-servers setups to

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,9 +90,9 @@ import SoftwarePreview, { SoftwarePreviewType } from "@/components/data/Software
       </div>
       <div class="flex-1">
         <h2 class="text-2xl font-semibold break-all md:text-4xl">
-          Powering
-          <PlayersCount client:load="svelte" ttlMs={12 * 60 * 1000} />
-          players
+          Powering <PlayersCount
+          client:load="svelte" ttlMs={12 * 60 * 1000}
+        /> players
         </h2>
         <p class="mt-3 text-gray-900 md:mt-6 md:text-xl dark:text-gray-100">
           PaperMC&apos;s software powers hundreds of thousands of Minecraft servers on a daily basis, from small single-servers setups to

--- a/src/pages/software/folia.astro
+++ b/src/pages/software/folia.astro
@@ -50,9 +50,9 @@ import { Image } from "astro:assets";
       <div class="flex-1">
         <h2 class="text-2xl font-semibold md:text-4xl">A diverse plugin ecosystem</h2>
         <div class="md:(mt-6 text-xl) mt-3 text-gray-900 dark:text-gray-100">
-          Crafted by the PaperMC team & contributors, Hangar is our own dedicated plugin repository, now in open beta! View over
-          <span class="text-blue-500">100</span>
-          different plugins that support Folia, or list your own with a very streamlined creation process.
+          Crafted by the PaperMC team & contributors, Hangar is our own dedicated plugin repository, now in open beta! View over <span
+            class="text-blue-500">100</span
+          > different plugins that support Folia, or list your own with a very streamlined creation process.
         </div>
         <div class="mt-8 flex flex-row gap-4">
           <Button variant="filled" href="https://hangar.papermc.io/" external dense> Check out Hangar </Button>

--- a/src/pages/software/paper.astro
+++ b/src/pages/software/paper.astro
@@ -59,9 +59,9 @@ const { pagination } = await getHangarProjects("paper");
       <div class="flex-1">
         <h2 class="text-2xl font-semibold md:text-4xl">A diverse plugin ecosystem</h2>
         <div class="mt-3 text-gray-900 md:mt-6 md:text-xl dark:text-gray-100">
-          Crafted by the PaperMC team & contributors, Hangar is our own dedicated plugin repository, now in open beta! View
-          <span class="text-blue-500">{pagination.count}</span>
-          different plugins that are specific to Paper, or list your own with a very streamlined creation process.
+          Crafted by the PaperMC team & contributors, Hangar is our own dedicated plugin repository, now in open beta! View <span
+            class="text-blue-500">{pagination.count}</span
+          > different plugins that are specific to Paper, or list your own with a very streamlined creation process.
         </div>
         <div class="mt-8 flex flex-row gap-4">
           <Button variant="filled" href="https://hangar.papermc.io/" external dense> Check out Hangar </Button>

--- a/src/pages/software/velocity.astro
+++ b/src/pages/software/velocity.astro
@@ -58,9 +58,9 @@ const { pagination } = await getHangarProjects("velocity");
       <div class="flex-1">
         <h2 class="text-2xl font-semibold md:text-4xl">A diverse plugin ecosystem</h2>
         <div class="mt-3 text-gray-900 md:mt-6 md:text-xl dark:text-gray-100">
-          Crafted by the PaperMC team & contributors, Hangar is our own dedicated plugin repository, now in open beta! View over
-          <span class="text-blue-500">{pagination.count}</span>
-          different plugins that are specific to Velocity, or list your own with a very streamlined creation process.
+          Crafted by the PaperMC team & contributors, Hangar is our own dedicated plugin repository, now in open beta! View over <span
+            class="text-blue-500">{pagination.count}</span
+          > different plugins that are specific to Velocity, or list your own with a very streamlined creation process.
         </div>
         <div class="mt-8 flex flex-row gap-4">
           <Button variant="filled" href="https://hangar.papermc.io/" external dense> Check out Hangar </Button>


### PR DESCRIPTION
This is a cleaner follow-up to #333.

It keeps the spacing fixes for the Folia, Velocity, and Paper plugin counts, along with the missing spacing around the player count and highlighted text on the homepage.

I left out the Waterfall commit from #333 since that formatting wasn't preferred.

Fixes #341.
Related to #345.